### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "c"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 Per compilare e buildare i file dovrebbe andar bene un qualsiasi comiplatore C. Tutti e 3 i file (main.c, stack.c, stack.h) sono necessari per il corretto funzionamento del programma. È presente anche un file di testing, chiamato "test.jas".
 Come ho scritto nel programma, se il file con codice IJVM è nella in cui si compilano i file non dovrebbe essere necessario inserire il percorso di quel file, altrimenti è necessario. 
+[![Run on Repl.it](https://repl.it/badge/github/musna0/compilerIJVM)](https://repl.it/github/musna0/compilerIJVM)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).